### PR TITLE
chore: replace liveness.sh by plain command

### DIFF
--- a/charts/tce-all-in-one/Chart.yaml
+++ b/charts/tce-all-in-one/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2-rc.1
+version: 0.2.2-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tce-all-in-one/templates/01-tce-deployments.yaml
+++ b/charts/tce-all-in-one/templates/01-tce-deployments.yaml
@@ -26,13 +26,16 @@ spec:
           startupProbe:
             {{ if eq $.Values.mode "boot" }}
             exec:
-              command: ["/tmp/liveness.sh", "{{ $.Values.mode }}"]
+              command:
+                - /bin/bash
+                - -c
+                - topos tce push-peer-list --node http://localhost:1340 --format json /tmp/shared/peer_ids.json;
             {{ else }}
             exec:
               command:
                 - /bin/bash
                 - -c
-                - PEER=$(topos tce keys --from-seed=$HOSTNAME); NODE="http://$HOSTNAME:1340"; /tmp/liveness.sh "{{ $.Values.mode }}" && { ( flock --exclusive -w 10 201 || exit 1; cat <<< $(jq --arg PEER $PEER '. |= (. + [$PEER] | unique )' /tmp/shared/peer_ids.json) > /tmp/shared/peer_ids.json;) 201>"/tmp/shared/peer_ids.json.lock"; ( flock --exclusive -w 10 200 || exit 1; cat <<< $(jq --arg NODE $NODE '.nodes |= (. + [$NODE] | unique)' /tmp/shared/peer_nodes.json) > /tmp/shared/peer_nodes.json;) 200>"/tmp/shared/peer_nodes.json.lock"; exit 0; } || { ( flock --exclusive -w 10 201 || exit 1; cat <<< $(jq --arg PEER $PEER '. |= (. - [$PEER])' /tmp/shared/peer_ids.json) > /tmp/shared/peer_ids.json;) 201>"/tmp/shared/peer_ids.json.lock"; ( flock --exclusive -w 10 200 || exit 1; cat <<< $(jq --arg NODE $NODE '.nodes |= (. - [$NODE])' /tmp/shared/peer_nodes.json) > /tmp/shared/peer_nodes.json;) 200>"/tmp/shared/peer_nodes.json.lock"; exit 1; };
+                - PEER=$(topos tce keys --from-seed=$HOSTNAME); NODE="http://$HOSTNAME:1340"; { topos tce push-peer-list --node http://localhost:1340 --format json /tmp/shared/peer_ids.json && topos tce status --node http://localhost:1340; } && { ( flock --exclusive -w 10 201 || exit 1; cat <<< $(jq --arg PEER $PEER '. |= (. + [$PEER] | unique )' /tmp/shared/peer_ids.json) > /tmp/shared/peer_ids.json;) 201>"/tmp/shared/peer_ids.json.lock"; ( flock --exclusive -w 10 200 || exit 1; cat <<< $(jq --arg NODE $NODE '.nodes |= (. + [$NODE] | unique)' /tmp/shared/peer_nodes.json) > /tmp/shared/peer_nodes.json;) 200>"/tmp/shared/peer_nodes.json.lock"; exit 0; } || { ( flock --exclusive -w 10 201 || exit 1; cat <<< $(jq --arg PEER $PEER '. |= (. - [$PEER])' /tmp/shared/peer_ids.json) > /tmp/shared/peer_ids.json;) 201>"/tmp/shared/peer_ids.json.lock"; ( flock --exclusive -w 10 200 || exit 1; cat <<< $(jq --arg NODE $NODE '.nodes |= (. - [$NODE])' /tmp/shared/peer_nodes.json) > /tmp/shared/peer_nodes.json;) 200>"/tmp/shared/peer_nodes.json.lock"; exit 1; };
             {{ end }}
             initialDelaySeconds: 10
             periodSeconds: 5


### PR DESCRIPTION
# Description

The `topos-network/topos` repository is under frequent changes. In this PR the `liveness.sh` command is being replaced by raw `topos` commands.

## Additions and Changes
### Bug fix (non-breaking change which fixes an issue)
The `--endpoint` argument was replaced by `--node`. 

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
