### PR TITLE
chore: add anti-affinity and remove requests and limits

### DIFF
--- a/charts/tce-all-in-one/Chart.yaml
+++ b/charts/tce-all-in-one/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2-rc.3
+version: 0.2.2-rc.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tce-all-in-one/templates/01-tce-deployments.yaml
+++ b/charts/tce-all-in-one/templates/01-tce-deployments.yaml
@@ -19,6 +19,18 @@ spec:
         node: {{ $.Values.mode }}
     spec:
       hostname: {{ $.Values.mode }}-{{ $index }}
+      {{ if $.Values.singleTCENodePerK8sNode }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: node
+                    operator: In
+                    values:
+                      - {{ $.Values.mode }}
+              topologyKey: "kubernetes.io/hostname"
+      {{ end }}
       containers:
         - name: {{ $.Values.mode }}
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
@@ -50,13 +62,6 @@ spec:
             - name: http
               containerPort: {{ $.Values.ports.http }}
               protocol: TCP
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "250m"
-            limits:
-              memory: "128Mi"
-              cpu: "500m"
           volumeMounts:
             - mountPath: /tmp/shared
               name: shared

--- a/charts/tce-all-in-one/values.yaml
+++ b/charts/tce-all-in-one/values.yaml
@@ -6,6 +6,9 @@ replicas: 5
 # mode can be (boot | peer)
 mode: boot
 
+# deploy a single TCE node per K8s node
+singleTCENodePerK8sNode: true
+
 host: nowhere.com
 # create ingress (true | false)
 ingress: false


### PR DESCRIPTION
# Description

When assigning pods to nodes in Kubernetes, there are several options to consider, such as: [node selectors](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels) to match labels on nodes with labels on pods, [taints and tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to control which pods can be scheduled on which nodes based on node conditions, and [node affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to ensure or avoid scheduling on specific nodes.

To deploy one pod per node on Kubernetes using node anti-affinity, we can create a `PodAntiAffinity` policy with a `requiredDuringSchedulingIgnoredDuringExecution` rule to enforce that pods should not be scheduled on nodes that already have a pod from the same anti-affinity group, effectively ensuring one pod per node.

This is done by verifying if the node already has a pod with the label `node={{ $.Values.mode }}`, where `{{ $.Values.mode }}` can `peer | boot`.

Fixes # (TOO-287)

## Additions and Changes

To configure the Helm chart to deploy one pod per node, the field `singleTCENodePerK8sNode` can be set to `true`, in order to prevent multiple pods from being scheduled on the same node

###  Example

With a cluster with 9 nodes:
<img width="1643" alt="Screenshot 2023-04-27 at 4 54 17 PM" src="https://user-images.githubusercontent.com/11741977/234980993-1c7ff4aa-fe24-4425-b3e7-568db2f9c38e.png">

Trying to deploy 20 TCE nodes with `singleTCENodePerK8sNode=true`

<img width="1643" alt="Screenshot 2023-04-27 at 4 54 08 PM" src="https://user-images.githubusercontent.com/11741977/234980908-3b04301b-775d-4020-b746-275bc7e7bec5.png">

Now trying to deploy 20 TCE nodes with `singleTCENodePerK8sNode=false`

<img width="1643" alt="Screenshot 2023-04-27 at 5 02 14 PM" src="https://user-images.githubusercontent.com/11741977/234981165-7f5a39ab-cf67-47ef-a4a2-a34bfbb3460d.png">


## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
