### PR TITLE
chore: set otel log verbosity to debug

### DIFF
--- a/charts/topos-observability/Chart.yaml
+++ b/charts/topos-observability/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26
+version: 0.1.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topos-observability/templates/01-observability-resources.yaml
+++ b/charts/topos-observability/templates/01-observability-resources.yaml
@@ -46,6 +46,8 @@ spec:
       telemetry:
         metrics:
           address: 0.0.0.0:8888
+        logs:
+          level: "debug"
       extensions:
         - health_check
         - memory_ballast


### PR DESCRIPTION
# Description

This PR sets the logging verbosity of the otel collector to `DEBUG`.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
